### PR TITLE
Fix errors on Redmine 4.x

### DIFF
--- a/app/controllers/json_rpc_call_controller.rb
+++ b/app/controllers/json_rpc_call_controller.rb
@@ -1,8 +1,8 @@
 class JsonRpcCallController < ApplicationController
   unloadable
 
-  before_filter :require_admin
-  before_filter :authorize_global
+  before_action :require_admin
+  before_action :authorize_global
   accept_api_auth :handle_rpc_request  
 
   def handle_rpc_request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,1 @@
-ActionController::Routing::Routes.draw do |map|
-  map.connect 'json_rpc_call.:format', :controller => 'json_rpc_call', :action => 'handle_rpc_request'
-end
+match 'json_rpc_call.:format', :controller => 'json_rpc_call', :action => 'handle_rpc_request', :via => [:get, :post, :delete, :put, :patch]


### PR DESCRIPTION
Thanks for making the wonderful plugin to extend the Redmine API.
After fixing a few lines it works with Redmine 4.1.

Fixed errors:
- An error occurred while loading the routes definition of
redmine_json_rpc plugin
(/usr/src/redmine/plugins/redmine_json_rpc/config/routes.rb):
uninitialized constant ActionController::Routing.
- undefined method `before_filter' for JsonRpcCallController:Class
(NoMethodError)

Here is my test result to list all the roles

```shell
REDMINE=localhost:8080
ADMIN_API_KEY=<APIKEY>
curl -v http://$REDMINE/json_rpc_call.json?key=$ADMIN_API_KEY -X POST -H "Content-Type: application/json" -d '{"class": "Role", "method" : "all", "params" : []}' | jq
```

